### PR TITLE
Deprecate: update README before archiving repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Archived. Profiles work has moved to https://github.com/weaveworks/weave-gitops
+
 # Profiles website
 
 This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.


### PR DESCRIPTION
### Description

`pctl` & `profiles` were archived in https://github.com/weaveworks/corp/pull/2371. <profiles.dev> was short lived, and I believe this repo can now also be archived.

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` (diagrams, usage, roadmap etc), and anything in `examples/`)
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] Added a `kind` label to the PR (must be one of the labels in [pr-labels.yaml](https://github.com/weaveworks/profiles-userdocs/blob/main/.github/workflows/pr-labels.yaml#L16))
